### PR TITLE
Add technical message type for onboarding VCUs

### DIFF
--- a/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/enums/TechnicalMessageType.kt
+++ b/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/enums/TechnicalMessageType.kt
@@ -2,6 +2,7 @@ package com.dke.data.agrirouter.api.enums
 
 enum class TechnicalMessageType(val key: String) {
 
+    DKE_ONBOARD_VCU("dke:cloud_onboard_endpoints"),
     DKE_CAPABILITIES("dke:capabilities"),
     DKE_SUBSCRIPTION("dke:subscription"),
     DKE_LIST_ENDPOINTS("dke:list_endpoints"),

--- a/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/enums/TechnicalMessageType.kt
+++ b/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/enums/TechnicalMessageType.kt
@@ -2,7 +2,7 @@ package com.dke.data.agrirouter.api.enums
 
 enum class TechnicalMessageType(val key: String) {
 
-    DKE_ONBOARD_VCU("dke:cloud_onboard_endpoints"),
+    DKE_CLOUD_ONBOARD_ENDPOINTS("dke:cloud_onboard_endpoints"),
     DKE_CAPABILITIES("dke:capabilities"),
     DKE_SUBSCRIPTION("dke:subscription"),
     DKE_LIST_ENDPOINTS("dke:list_endpoints"),


### PR DESCRIPTION
As telemetry platform, we need to onboard VCUs.
So the technical message type dke:cloud_onboard_endpoints is necessary.
This pull request adds the mentioned enum value.