### PR TITLE
removed not used interfaces

### DIFF
--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/FetchMessageServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/FetchMessageServiceImpl.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class FetchMessageServiceImpl
-    implements FetchMessageService, MessageFetcher, ResponseValidator {
+    implements FetchMessageService, MessageFetcher {
 
   public Optional<List<FetchMessageResponse>> fetch(
       OnboardingResponse onboardingResponse, int maxTries, long interval) {

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageHeaderQueryServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageHeaderQueryServiceImpl.java
@@ -13,7 +13,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 public class MessageHeaderQueryServiceImpl extends EnvironmentalService
-    implements MessageHeaderQueryService, MessageSender, ResponseValidator {
+    implements MessageHeaderQueryService, MessageSender {
 
   private final MessageQueryService messageQueryService;
 

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageQueryServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageQueryServiceImpl.java
@@ -15,8 +15,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 public class MessageQueryServiceImpl extends EnvironmentalService
     implements com.dke.data.agrirouter.api.service.messaging.MessageQueryService,
         MessageSender,
-        MessageDecoder<FeedResponse.MessageQueryResponse>,
-        ResponseValidator {
+        MessageDecoder<FeedResponse.MessageQueryResponse> {
 
   private final MessageQueryService messageQueryService;
 


### PR DESCRIPTION
Some services implemented `ResponseValidator` without using the implemented default methods. 