### PR TITLE
Feature/check status code range

### DIFF
--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/DeleteMessageServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/DeleteMessageServiceImpl.java
@@ -38,7 +38,7 @@ public class DeleteMessageServiceImpl
 
     MessageSenderResponse response = this.sendMessage(sendMessageParameters);
 
-    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK);
+    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK, false);
   }
 
   private String encodeMessage(DeleteMessageParameters parameters) {

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageConfirmationServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageConfirmationServiceImpl.java
@@ -56,7 +56,7 @@ public class MessageConfirmationServiceImpl extends EnvironmentalService
 
     MessageSenderResponse response = this.sendMessage(sendMessageParameters);
 
-    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK);
+    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK, false);
   }
 
   private String encodeMessage(MessageConfirmationParameters parameters) {

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageFetcher.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageFetcher.java
@@ -28,7 +28,7 @@ public interface MessageFetcher extends ResponseValidator {
                   CertificationType.valueOf(
                       parameters.getOnboardingResponse().getAuthentication().getType()))
               .get();
-      this.assertResponseStatusIsValid(response, HttpStatus.SC_OK);
+      this.assertResponseStatusIsValid(response, HttpStatus.SC_OK, false);
       String entityContent = response.readEntity(String.class);
       if (!StringUtils.equalsIgnoreCase(entityContent, EMPTY_CONTENT)) {
         return Optional.of(entityContent);

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/SendMessageServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/SendMessageServiceImpl.java
@@ -12,6 +12,6 @@ public class SendMessageServiceImpl
   public void send(SendMessageParameters parameters) {
     parameters.validate();
     MessageSenderResponse response = this.sendMessage(parameters);
-    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK);
+    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK, false);
   }
 }

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/SetCapabilityServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/SetCapabilityServiceImpl.java
@@ -42,7 +42,7 @@ public class SetCapabilityServiceImpl extends EnvironmentalService
 
     MessageSenderResponse response = this.sendMessage(sendMessageParameters);
 
-    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK);
+    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK, false);
   }
 
   private String encodeMessage(SetCapabilitiesParameters parameters) {

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/OnboardingServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/OnboardingServiceImpl.java
@@ -53,7 +53,7 @@ public class OnboardingServiceImpl extends AbstractOnboardingService
     Response response =
         RequestFactory.bearerTokenRequest(this.environment.getOnboardUrl(), registrationCode)
             .post(Entity.json(onboardingRequest));
-    this.assertResponseStatusIsValid(response, HttpStatus.SC_CREATED);
+    this.assertResponseStatusIsValid(response, HttpStatus.SC_CREATED, false);
     OnboardingResponse onboardingResponse = response.readEntity(OnboardingResponse.class);
 
     this.getNativeLogger()

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/RegistrationRequestServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/RegistrationRequestServiceImpl.java
@@ -43,7 +43,7 @@ public class RegistrationRequestServiceImpl extends EnvironmentalService
     Response response = RequestFactory.request(url, cookies).get();
 
     this.getNativeLogger().debug("Validating response | {}.", response);
-    this.assertResponseStatusIsValid(response, HttpStatus.SC_OK);
+    this.assertResponseStatusIsValid(response, HttpStatus.SC_OK, false);
 
     this.getNativeLogger()
         .info("END | Fetching registration code from agrirouter | '{}'.", parameters);

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/secured/OnboardingServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/secured/OnboardingServiceImpl.java
@@ -74,7 +74,7 @@ public class OnboardingServiceImpl extends AbstractOnboardingService
                 securedOnboardingParameters.getApplicationId(),
                 encodedSignature)
             .post(Entity.entity(jsonBody, MediaType.APPLICATION_JSON_TYPE));
-    this.assertResponseStatusIsValid(response, HttpStatus.SC_CREATED);
+    this.assertResponseStatusIsValid(response, HttpStatus.SC_CREATED, false);
     return response.readEntity(OnboardingResponse.class);
   }
 
@@ -95,7 +95,7 @@ public class OnboardingServiceImpl extends AbstractOnboardingService
                 encodedSignature)
             .post(Entity.entity(jsonBody, MediaType.APPLICATION_JSON_TYPE));
     try {
-      this.assertResponseStatusIsValid(response, HttpStatus.SC_OK);
+      this.assertResponseStatusIsValid(response, HttpStatus.SC_OK, false);
     } catch (UnexpectedHttpStatusException e) {
       throw new CouldNotVerifySecuredOnboardingRequestException(e);
     }

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/secured/RegistrationRequestServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/secured/RegistrationRequestServiceImpl.java
@@ -78,7 +78,7 @@ public class RegistrationRequestServiceImpl extends EnvironmentalService
 
       HtmlAnchor anchorByHref = page.getAnchorByHref("javascript:{}");
       final Page redirectPage = anchorByHref.click();
-      assertResponseStatusIsValid(redirectPage.getWebResponse(), HttpStatus.SC_OK);
+      assertResponseStatusIsValid(redirectPage.getWebResponse(), HttpStatus.SC_OK, false);
 
       URL redirectPageUrl = redirectPage.getUrl();
       return this.extractAuthenticationResults(redirectPageUrl);

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/validation/ResponseValidator.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/validation/ResponseValidator.java
@@ -14,7 +14,30 @@ import org.apache.logging.log4j.message.ObjectArrayMessage;
 /** Validation of the response, encapsulated using an interface. */
 public interface ResponseValidator {
 
+  int HTTP_STATUS_OK_MIN = 200;
+  int HTTP_STATUS_OK_MAX = 299;
+
   Logger LOGGER = LogManager.getLogger();
+
+  /**
+   * Will assert, that the response status is valid. If there will be an 404 or 401 a business
+   * exception will rise.
+   *
+   * @param response The current response.
+   * @param exceptedHttpStatus The expected HTTP status.
+   * @param checkRange If a range check should be performed
+   */
+  default void assertResponseStatusIsValid(Response response, int exceptedHttpStatus, boolean checkRange) {
+    LOGGER.debug("Validating response.");
+    LOGGER.trace(new ObjectArrayMessage(response, exceptedHttpStatus, checkRange));
+
+    int actualHttpStatus = this.getStatus(response);
+    if (checkRange) {
+      this.assertResponseStatusIsValidWithRange(actualHttpStatus, HTTP_STATUS_OK_MIN, HTTP_STATUS_OK_MAX);
+    } else {
+      this.assertResponseStatusIsValidWithoutRange(actualHttpStatus, exceptedHttpStatus);
+    }
+  }
 
   /**
    * Will assert, that the response status is valid. If there will be an 404 or 401 a business
@@ -26,18 +49,9 @@ public interface ResponseValidator {
   default void assertResponseStatusIsValid(Response response, int exceptedHttpStatus) {
     LOGGER.debug("Validating response.");
     LOGGER.trace(new ObjectArrayMessage(response, exceptedHttpStatus));
-    if (response.getStatus() == HttpStatus.SC_NOT_FOUND) {
-      throw new InvalidUrlForRequestException();
-    }
-    if (response.getStatus() == HttpStatus.SC_UNAUTHORIZED) {
-      throw new UnauthorizedRequestException();
-    }
-    if (response.getStatus() == HttpStatus.SC_FORBIDDEN) {
-      throw new ForbiddenRequestException();
-    }
-    if (response.getStatus() != exceptedHttpStatus) {
-      throw new UnexpectedHttpStatusException(response.getStatus(), exceptedHttpStatus);
-    }
+
+    int actualHttpStatus = this.getStatus(response);
+    this.assertResponseStatusIsValidWithoutRange(actualHttpStatus, exceptedHttpStatus);
   }
 
   /**
@@ -50,17 +64,82 @@ public interface ResponseValidator {
   default void assertResponseStatusIsValid(WebResponse response, int exceptedHttpStatus) {
     LOGGER.debug("Validating response.");
     LOGGER.trace(new ObjectArrayMessage(response, exceptedHttpStatus));
-    if (response.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+
+    int actualHttpStatus = this.getStatus(response);
+    this.assertResponseStatusIsValidWithoutRange(actualHttpStatus, exceptedHttpStatus);
+  }
+
+  default void assertResponseStatusIsValidWithoutRange(int actualStatus, int expectedStatus) {
+    if (actualStatus == HttpStatus.SC_NOT_FOUND) {
       throw new InvalidUrlForRequestException();
     }
-    if (response.getStatusCode() == HttpStatus.SC_UNAUTHORIZED) {
+    if (actualStatus == HttpStatus.SC_UNAUTHORIZED) {
       throw new UnauthorizedRequestException();
     }
-    if (response.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+    if (actualStatus == HttpStatus.SC_FORBIDDEN) {
       throw new ForbiddenRequestException();
     }
-    if (response.getStatusCode() != exceptedHttpStatus) {
-      throw new UnexpectedHttpStatusException(response.getStatusCode(), exceptedHttpStatus);
+    if (actualStatus != expectedStatus) {
+      throw new UnexpectedHttpStatusException(actualStatus, expectedStatus);
     }
+  }
+
+
+  /**
+   * Will assert, that the response status is within a valid range. If there will be an 404 or 401 a business
+   * exception will rise.
+   *
+   * @param response The current response.
+   * @param expectedMinimumState the minimum allowed value
+   * @param expectedMaximumState the maximum value allowed
+   */
+  default void assertResponseStatusIsInRange(Response response, int expectedMinimumState, int expectedMaximumState){
+    LOGGER.debug("Validating response in Range.");
+    LOGGER.trace(new ObjectArrayMessage(response, expectedMinimumState,expectedMaximumState));
+
+    int status = this.getStatus(response);
+    this.assertResponseStatusIsValidWithRange(status, expectedMinimumState, expectedMaximumState);
+  }
+
+  /**
+   * Will assert, that the response status is within a valid range. If there will be an 404 or 401 a business
+   * exception will rise.
+   *
+   * @param response The current response.
+   * @param expectedMinimumState the minimum allowed value
+   * @param expectedMaximumState the maximum value allowed
+   */
+  default void assertResponseStatusIsInRange(WebResponse response, int expectedMinimumState, int expectedMaximumState){
+    LOGGER.debug("Validating response in Range.");
+    LOGGER.trace(new ObjectArrayMessage(response, expectedMinimumState,expectedMaximumState));
+
+    int status = this.getStatus(response);
+    this.assertResponseStatusIsValidWithRange(status, expectedMinimumState, expectedMaximumState);
+  }
+
+  default void assertResponseStatusIsValidWithRange(int actualStatus, int expectedMinimumState, int expectedMaximumState) {
+    if (actualStatus == HttpStatus.SC_NOT_FOUND) {
+      throw new InvalidUrlForRequestException();
+    }
+    if (actualStatus == HttpStatus.SC_UNAUTHORIZED) {
+      throw new UnauthorizedRequestException();
+    }
+    if (actualStatus == HttpStatus.SC_FORBIDDEN) {
+      throw new ForbiddenRequestException();
+    }
+    if (actualStatus < expectedMinimumState) {
+      throw new UnexpectedHttpStatusException(actualStatus, expectedMinimumState);
+    } else if (actualStatus > expectedMaximumState) {
+      throw new UnexpectedHttpStatusException(actualStatus, expectedMinimumState);
+    }
+  }
+
+
+  default int getStatus(WebResponse response) {
+    return response.getStatusCode();
+  }
+
+  default int getStatus(Response response) {
+    return response.getStatus();
   }
 }


### PR DESCRIPTION
Integrated range checking into its own method in `ResponseValidator`, which can be activated by calling instances. Existing calls to the method default to false, indicating no range checking. So behaviour is currently the same as before.

During refactoring of the changes made to the interface I created some helper methods, which unfortunately could not be made private...Let me know what you think about that.

This pull request should replace https://github.com/DKE-Data/agrirouter-api-java/pull/32, so that one could be closed.