### PR TITLE
Make Authorization Process usable as designed

### DIFF
--- a/agrirouter-api-java-api/src/main/java/com/dke/data/agrirouter/api/service/onboard/secured/RegistrationRequestService.java
+++ b/agrirouter-api-java-api/src/main/java/com/dke/data/agrirouter/api/service/onboard/secured/RegistrationRequestService.java
@@ -3,6 +3,7 @@ package com.dke.data.agrirouter.api.service.onboard.secured;
 import com.dke.data.agrirouter.api.dto.registrationrequest.secured.RegistrationRequestResponse;
 import com.dke.data.agrirouter.api.dto.registrationrequest.secured.RegistrationRequestToken;
 import com.dke.data.agrirouter.api.service.parameters.SecuredRegistrationRequestParameters;
+import java.net.URL;
 
 /** Service for the registration request. */
 public interface RegistrationRequestService {
@@ -10,5 +11,10 @@ public interface RegistrationRequestService {
   RegistrationRequestResponse getRegistrationCode(
       SecuredRegistrationRequestParameters securedRegistrationRequestParameters);
 
-  RegistrationRequestToken decode(String token);
+  String getRegistrationRequestURL(
+      SecuredRegistrationRequestParameters securedRegistrationRequestParameters);
+
+  RegistrationRequestToken decodeToken(String token);
+
+  RegistrationRequestResponse extractAuthenticationResults(URL redirectPageUrl);
 }

--- a/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/dto/registrationrequest/secured/RegistrationRequestResponse.kt
+++ b/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/dto/registrationrequest/secured/RegistrationRequestResponse.kt
@@ -12,4 +12,7 @@ class RegistrationRequestResponse {
     lateinit var token: String
     var error: String? = null
 
+    fun hasError():Boolean{
+        return error.equals("")
+    }
 }

--- a/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/dto/registrationrequest/secured/RegistrationRequestResponse.kt
+++ b/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/dto/registrationrequest/secured/RegistrationRequestResponse.kt
@@ -16,6 +16,6 @@ class RegistrationRequestResponse {
      * Returns true, if an error accoured while generating token serverside
      */
     fun hasError():Boolean{
-        return error.equals("")
+        return error.isNullOrBlank()
     }
 }

--- a/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/dto/registrationrequest/secured/RegistrationRequestResponse.kt
+++ b/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/dto/registrationrequest/secured/RegistrationRequestResponse.kt
@@ -12,6 +12,9 @@ class RegistrationRequestResponse {
     lateinit var token: String
     var error: String? = null
 
+    /**
+     * Returns true, if an error accoured while generating token serverside
+     */
     fun hasError():Boolean{
         return error.equals("")
     }

--- a/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/service/parameters/SecuredRegistrationRequestParameters.kt
+++ b/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/service/parameters/SecuredRegistrationRequestParameters.kt
@@ -1,5 +1,6 @@
 package com.dke.data.agrirouter.api.service.parameters
 
+import com.dke.data.agrirouter.api.enums.SecuredOnboardingResponseType
 import com.dke.data.agrirouter.api.service.ParameterValidation
 import lombok.ToString
 
@@ -11,7 +12,9 @@ class SecuredRegistrationRequestParameters : ParameterValidation {
 
     lateinit var applicationId : String
 
-    lateinit var redirectUri: String
+    var redirectUri: String = ""
 
-    var state: String = ""
+    lateinit var state: String
+
+    var responseType: SecuredOnboardingResponseType = SecuredOnboardingResponseType.ONBOARD
 }

--- a/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/service/parameters/SecuredRegistrationRequestParameters.kt
+++ b/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/service/parameters/SecuredRegistrationRequestParameters.kt
@@ -13,4 +13,5 @@ class SecuredRegistrationRequestParameters : ParameterValidation {
 
     lateinit var redirectUri: String
 
+    lateinit var state: String
 }

--- a/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/service/parameters/SecuredRegistrationRequestParameters.kt
+++ b/agrirouter-api-java-api/src/main/kotlin/com/dke/data/agrirouter/api/service/parameters/SecuredRegistrationRequestParameters.kt
@@ -13,5 +13,5 @@ class SecuredRegistrationRequestParameters : ParameterValidation {
 
     lateinit var redirectUri: String
 
-    lateinit var state: String
+    var state: String = ""
 }

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/cloud/OnboardingServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/cloud/OnboardingServiceImpl.java
@@ -31,198 +31,198 @@ import com.dke.data.agrirouter.impl.messaging.rest.MessageSender;
 import com.dke.data.agrirouter.impl.validation.ResponseValidator;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
 import org.apache.http.HttpStatus;
 
 public class OnboardingServiceImpl implements OnboardingService, MessageSender, ResponseValidator {
 
-    private final EncodeMessageService encodeMessageService;
-    private final FetchMessageService fetchMessageService;
-    private final DecodeMessageService decodeMessageService;
+  private final EncodeMessageService encodeMessageService;
+  private final FetchMessageService fetchMessageService;
+  private final DecodeMessageService decodeMessageService;
 
-    public OnboardingServiceImpl() {
-        this.encodeMessageService = new EncodeMessageServiceImpl();
-        this.fetchMessageService = new FetchMessageServiceImpl();
-        this.decodeMessageService = new DecodeMessageServiceImpl();
-    }
+  public OnboardingServiceImpl() {
+    this.encodeMessageService = new EncodeMessageServiceImpl();
+    this.fetchMessageService = new FetchMessageServiceImpl();
+    this.decodeMessageService = new DecodeMessageServiceImpl();
+  }
 
-    /**
-     * Onboarding a virtual CU for an existing cloud application (incl. several checks).
-     *
-     * @param parameters Parameters for the onboarding.
-     * @return -
-     */
-    @Override
-    public List<OnboardingResponse> onboard(CloudOnboardingParameters parameters) {
-        parameters.validate();
-        EncodeMessageResponse encodedMessageResponse = this.encodeOnboardingMessage(parameters);
-        SendMessageParameters sendMessageParameters =
-                createSendMessageParameters(encodedMessageResponse, parameters.getOnboardingResponse());
-        Optional<List<FetchMessageResponse>> fetchMessageResponses =
-                sendMessageAndFetchResponses(sendMessageParameters, parameters.getOnboardingResponse());
+  /**
+   * Onboarding a virtual CU for an existing cloud application (incl. several checks).
+   *
+   * @param parameters Parameters for the onboarding.
+   * @return -
+   */
+  @Override
+  public List<OnboardingResponse> onboard(CloudOnboardingParameters parameters) {
+    parameters.validate();
+    EncodeMessageResponse encodedMessageResponse = this.encodeOnboardingMessage(parameters);
+    SendMessageParameters sendMessageParameters =
+        createSendMessageParameters(encodedMessageResponse, parameters.getOnboardingResponse());
+    Optional<List<FetchMessageResponse>> fetchMessageResponses =
+        sendMessageAndFetchResponses(sendMessageParameters, parameters.getOnboardingResponse());
 
-        List<OnboardingResponse> responses = new ArrayList<>();
-        if (fetchMessageResponses.isPresent()) {
-            DecodeMessageResponse decodedMessageQueryResponse =
-                    this.decodeMessageService.decode(
-                            fetchMessageResponses.get().get(0).getCommand().getMessage());
-            if (decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
-                    == HttpStatus.SC_BAD_REQUEST) {
-                MessageOuterClass.Message message =
-                        this.decodeMessageService.decode(
-                                decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
-                throw new CouldNotOnboardVirtualCommunicationUnitException(message.getMessage());
-            } else {
-                if (decodedMessageQueryResponse.getResponseEnvelope().getType()
-                        == Response.ResponseEnvelope.ResponseBodyType.CLOUD_REGISTRATIONS
-                        && decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
-                        == HttpStatus.SC_CREATED) {
-                    CloudVirtualizedAppRegistration.OnboardingResponse onboardingResponse =
-                            this.decode(
-                                    decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
-                    onboardingResponse
-                            .getOnboardedEndpointsList()
-                            .forEach(
-                                    endpointRegistrationDetails -> {
-                                        OnboardingResponse internalOnboardingResponse = new OnboardingResponse();
-                                        internalOnboardingResponse.setSensorAlternateId(
-                                                endpointRegistrationDetails.getSensorAlternateId());
-                                        internalOnboardingResponse.setCapabilityAlternateId(
-                                                endpointRegistrationDetails.getCapabilityAlternateId());
-                                        internalOnboardingResponse.setDeviceAlternateId(
-                                                endpointRegistrationDetails.getDeviceAlternateId());
-                                        internalOnboardingResponse.setAuthentication(
-                                                parameters.getOnboardingResponse().getAuthentication());
-                                        internalOnboardingResponse.setConnectionCriteria(
-                                                parameters.getOnboardingResponse().getConnectionCriteria());
-                                        responses.add(internalOnboardingResponse);
-                                    });
-                }
-            }
+    List<OnboardingResponse> responses = new ArrayList<>();
+    if (fetchMessageResponses.isPresent()) {
+      DecodeMessageResponse decodedMessageQueryResponse =
+          this.decodeMessageService.decode(
+              fetchMessageResponses.get().get(0).getCommand().getMessage());
+      if (decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
+          == HttpStatus.SC_BAD_REQUEST) {
+        MessageOuterClass.Message message =
+            this.decodeMessageService.decode(
+                decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
+        throw new CouldNotOnboardVirtualCommunicationUnitException(message.getMessage());
+      } else {
+        if (decodedMessageQueryResponse.getResponseEnvelope().getType()
+                == Response.ResponseEnvelope.ResponseBodyType.CLOUD_REGISTRATIONS
+            && decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
+                == HttpStatus.SC_CREATED) {
+          CloudVirtualizedAppRegistration.OnboardingResponse onboardingResponse =
+              this.decode(
+                  decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
+          onboardingResponse
+              .getOnboardedEndpointsList()
+              .forEach(
+                  endpointRegistrationDetails -> {
+                    OnboardingResponse internalOnboardingResponse = new OnboardingResponse();
+                    internalOnboardingResponse.setSensorAlternateId(
+                        endpointRegistrationDetails.getSensorAlternateId());
+                    internalOnboardingResponse.setCapabilityAlternateId(
+                        endpointRegistrationDetails.getCapabilityAlternateId());
+                    internalOnboardingResponse.setDeviceAlternateId(
+                        endpointRegistrationDetails.getDeviceAlternateId());
+                    internalOnboardingResponse.setAuthentication(
+                        parameters.getOnboardingResponse().getAuthentication());
+                    internalOnboardingResponse.setConnectionCriteria(
+                        parameters.getOnboardingResponse().getConnectionCriteria());
+                    responses.add(internalOnboardingResponse);
+                  });
         }
-        return responses;
+      }
     }
+    return responses;
+  }
 
-    /**
-     * Offboarding a virtual CU. Will deliver no result if the action was successful, if there's any error an exception will be thrown.
-     * @param parameters Parameters for offboarding.
-     */
-    @Override
-    public void offboard(CloudOffboardingParameters parameters) {
-        parameters.validate();
-        EncodeMessageResponse encodedMessageResponse = this.encodeOffboardingMessage(parameters);
-        SendMessageParameters sendMessageParameters =
-                createSendMessageParameters(encodedMessageResponse, parameters.getOnboardingResponse());
-        Optional<List<FetchMessageResponse>> fetchMessageResponses =
-                sendMessageAndFetchResponses(sendMessageParameters, parameters.getOnboardingResponse());
-        if (fetchMessageResponses.isPresent()) {
-            DecodeMessageResponse decodedMessageQueryResponse =
-                    this.decodeMessageService.decode(
-                            fetchMessageResponses.get().get(0).getCommand().getMessage());
-            if (decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
-                    == HttpStatus.SC_BAD_REQUEST) {
-                MessageOuterClass.Message message =
-                        this.decodeMessageService.decode(
-                                decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
-                throw new CouldNotOffboardVirtualCommunicationUnitException(message.getMessage());
-            }
-        }
+  /**
+   * Offboarding a virtual CU. Will deliver no result if the action was successful, if there's any
+   * error an exception will be thrown.
+   *
+   * @param parameters Parameters for offboarding.
+   */
+  @Override
+  public void offboard(CloudOffboardingParameters parameters) {
+    parameters.validate();
+    EncodeMessageResponse encodedMessageResponse = this.encodeOffboardingMessage(parameters);
+    SendMessageParameters sendMessageParameters =
+        createSendMessageParameters(encodedMessageResponse, parameters.getOnboardingResponse());
+    Optional<List<FetchMessageResponse>> fetchMessageResponses =
+        sendMessageAndFetchResponses(sendMessageParameters, parameters.getOnboardingResponse());
+    if (fetchMessageResponses.isPresent()) {
+      DecodeMessageResponse decodedMessageQueryResponse =
+          this.decodeMessageService.decode(
+              fetchMessageResponses.get().get(0).getCommand().getMessage());
+      if (decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
+          == HttpStatus.SC_BAD_REQUEST) {
+        MessageOuterClass.Message message =
+            this.decodeMessageService.decode(
+                decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
+        throw new CouldNotOffboardVirtualCommunicationUnitException(message.getMessage());
+      }
     }
+  }
 
-    private Optional<List<FetchMessageResponse>> sendMessageAndFetchResponses(
-            SendMessageParameters sendMessageParameters, OnboardingResponse onboardingResponse) {
-        MessageSenderResponse response = this.sendMessage(sendMessageParameters);
-        this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK);
-        return this.fetchMessageService.fetch(
-                onboardingResponse, MAX_TRIES_BEFORE_FAILURE, DEFAULT_INTERVAL);
-    }
+  private Optional<List<FetchMessageResponse>> sendMessageAndFetchResponses(
+      SendMessageParameters sendMessageParameters, OnboardingResponse onboardingResponse) {
+    MessageSenderResponse response = this.sendMessage(sendMessageParameters);
+    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK);
+    return this.fetchMessageService.fetch(
+        onboardingResponse, MAX_TRIES_BEFORE_FAILURE, DEFAULT_INTERVAL);
+  }
 
-    private EncodeMessageResponse encodeOnboardingMessage(CloudOnboardingParameters parameters) {
-        final String applicationMessageID = MessageIdService.generateMessageId();
+  private EncodeMessageResponse encodeOnboardingMessage(CloudOnboardingParameters parameters) {
+    final String applicationMessageID = MessageIdService.generateMessageId();
 
-        List<CloudEndpointOnboardingMessageParameters> onboardCloudEndpointMessageParameters =
-                new ArrayList<>();
-        parameters
-                .getEndpointDetails()
-                .forEach(
-                        endpointDetailsParameters -> {
-                            CloudEndpointOnboardingMessageParameters onboardCloudEndpointMessageParameter =
-                                    new CloudEndpointOnboardingMessageParameters();
-                            onboardCloudEndpointMessageParameter.setEndpointId(
-                                    endpointDetailsParameters.getEndpointId());
-                            onboardCloudEndpointMessageParameter.setEndpointName(
-                                    endpointDetailsParameters.getEndpointName());
-                            onboardCloudEndpointMessageParameters.add(onboardCloudEndpointMessageParameter);
-                        });
+    List<CloudEndpointOnboardingMessageParameters> onboardCloudEndpointMessageParameters =
+        new ArrayList<>();
+    parameters
+        .getEndpointDetails()
+        .forEach(
+            endpointDetailsParameters -> {
+              CloudEndpointOnboardingMessageParameters onboardCloudEndpointMessageParameter =
+                  new CloudEndpointOnboardingMessageParameters();
+              onboardCloudEndpointMessageParameter.setEndpointId(
+                  endpointDetailsParameters.getEndpointId());
+              onboardCloudEndpointMessageParameter.setEndpointName(
+                  endpointDetailsParameters.getEndpointName());
+              onboardCloudEndpointMessageParameters.add(onboardCloudEndpointMessageParameter);
+            });
 
-        PayloadParameters payloadParameters = new PayloadParameters();
-        payloadParameters.setTypeUrl(
-                CloudVirtualizedAppRegistration.OnboardingRequest.getDescriptor().getFullName());
-        payloadParameters.setValue(
-                new CloudEndpointOnboardingMessageContentFactory()
-                        .message(
-                                onboardCloudEndpointMessageParameters.toArray(
-                                        new CloudEndpointOnboardingMessageParameters
-                                                [onboardCloudEndpointMessageParameters.size()])));
+    PayloadParameters payloadParameters = new PayloadParameters();
+    payloadParameters.setTypeUrl(
+        CloudVirtualizedAppRegistration.OnboardingRequest.getDescriptor().getFullName());
+    payloadParameters.setValue(
+        new CloudEndpointOnboardingMessageContentFactory()
+            .message(
+                onboardCloudEndpointMessageParameters.toArray(
+                    new CloudEndpointOnboardingMessageParameters
+                        [onboardCloudEndpointMessageParameters.size()])));
 
-        String encodedMessage =
-                this.encodeMessageService.encode(
-                        this.createMessageHeaderParameters(applicationMessageID), payloadParameters);
-        return new EncodeMessageResponse(applicationMessageID, encodedMessage);
-    }
+    String encodedMessage =
+        this.encodeMessageService.encode(
+            this.createMessageHeaderParameters(applicationMessageID), payloadParameters);
+    return new EncodeMessageResponse(applicationMessageID, encodedMessage);
+  }
 
-    private EncodeMessageResponse encodeOffboardingMessage(CloudOffboardingParameters parameters) {
-        final String applicationMessageID = MessageIdService.generateMessageId();
+  private EncodeMessageResponse encodeOffboardingMessage(CloudOffboardingParameters parameters) {
+    final String applicationMessageID = MessageIdService.generateMessageId();
 
-        CloudEndpointOffboardingMessageParameters cloudOffboardingParameters =
-                new CloudEndpointOffboardingMessageParameters();
-        cloudOffboardingParameters.setEndpointIds(new ArrayList<>());
-        parameters
-                .getEndpointIds()
-                .forEach(
-                        endpointId -> {
-                            cloudOffboardingParameters.getEndpointIds().add(endpointId);
-                        });
+    CloudEndpointOffboardingMessageParameters cloudOffboardingParameters =
+        new CloudEndpointOffboardingMessageParameters();
+    cloudOffboardingParameters.setEndpointIds(new ArrayList<>());
+    parameters
+        .getEndpointIds()
+        .forEach(
+            endpointId -> {
+              cloudOffboardingParameters.getEndpointIds().add(endpointId);
+            });
 
-        PayloadParameters payloadParameters = new PayloadParameters();
-        payloadParameters.setTypeUrl(
-                CloudVirtualizedAppRegistration.OffboardingRequest.getDescriptor().getFullName());
+    PayloadParameters payloadParameters = new PayloadParameters();
+    payloadParameters.setTypeUrl(
+        CloudVirtualizedAppRegistration.OffboardingRequest.getDescriptor().getFullName());
 
-        payloadParameters.setValue(
-                new CloudEndpointOffboardingMessageContentFactory().message(cloudOffboardingParameters));
+    payloadParameters.setValue(
+        new CloudEndpointOffboardingMessageContentFactory().message(cloudOffboardingParameters));
 
-        String encodedMessage =
-                this.encodeMessageService.encode(
-                        this.createMessageHeaderParameters(applicationMessageID), payloadParameters);
-        return new EncodeMessageResponse(applicationMessageID, encodedMessage);
-    }
+    String encodedMessage =
+        this.encodeMessageService.encode(
+            this.createMessageHeaderParameters(applicationMessageID), payloadParameters);
+    return new EncodeMessageResponse(applicationMessageID, encodedMessage);
+  }
 
-    private MessageHeaderParameters createMessageHeaderParameters(String applicationMessageID) {
-        MessageHeaderParameters messageHeaderParameters = new MessageHeaderParameters();
-        messageHeaderParameters.setApplicationMessageId(applicationMessageID);
-        messageHeaderParameters.setTechnicalMessageType(
-                TechnicalMessageType.DKE_CLOUD_ONBOARD_ENDPOINTS);
-        messageHeaderParameters.setMode(Request.RequestEnvelope.Mode.DIRECT);
-        return messageHeaderParameters;
-    }
+  private MessageHeaderParameters createMessageHeaderParameters(String applicationMessageID) {
+    MessageHeaderParameters messageHeaderParameters = new MessageHeaderParameters();
+    messageHeaderParameters.setApplicationMessageId(applicationMessageID);
+    messageHeaderParameters.setTechnicalMessageType(
+        TechnicalMessageType.DKE_CLOUD_ONBOARD_ENDPOINTS);
+    messageHeaderParameters.setMode(Request.RequestEnvelope.Mode.DIRECT);
+    return messageHeaderParameters;
+  }
 
-    private SendMessageParameters createSendMessageParameters(
-            EncodeMessageResponse encodedMessageResponse, OnboardingResponse onboardingResponse) {
-        SendMessageParameters sendMessageParameters = new SendMessageParameters();
-        sendMessageParameters.setOnboardingResponse(onboardingResponse);
-        sendMessageParameters.setEncodedMessages(
-                Collections.singletonList(encodedMessageResponse.getEncodedMessage()));
-        return sendMessageParameters;
-    }
+  private SendMessageParameters createSendMessageParameters(
+      EncodeMessageResponse encodedMessageResponse, OnboardingResponse onboardingResponse) {
+    SendMessageParameters sendMessageParameters = new SendMessageParameters();
+    sendMessageParameters.setOnboardingResponse(onboardingResponse);
+    sendMessageParameters.setEncodedMessages(
+        Collections.singletonList(encodedMessageResponse.getEncodedMessage()));
+    return sendMessageParameters;
+  }
 
-    @Override
-    public CloudVirtualizedAppRegistration.OnboardingResponse unsafeDecode(ByteString message)
-            throws InvalidProtocolBufferException {
-        return CloudVirtualizedAppRegistration.OnboardingResponse.parseFrom(message);
-    }
+  @Override
+  public CloudVirtualizedAppRegistration.OnboardingResponse unsafeDecode(ByteString message)
+      throws InvalidProtocolBufferException {
+    return CloudVirtualizedAppRegistration.OnboardingResponse.parseFrom(message);
+  }
 }

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/cloud/OnboardingServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/cloud/OnboardingServiceImpl.java
@@ -39,190 +39,190 @@ import org.apache.http.HttpStatus;
 
 public class OnboardingServiceImpl implements OnboardingService, MessageSender, ResponseValidator {
 
-  private final EncodeMessageService encodeMessageService;
-  private final FetchMessageService fetchMessageService;
-  private final DecodeMessageService decodeMessageService;
+    private final EncodeMessageService encodeMessageService;
+    private final FetchMessageService fetchMessageService;
+    private final DecodeMessageService decodeMessageService;
 
-  public OnboardingServiceImpl() {
-    this.encodeMessageService = new EncodeMessageServiceImpl();
-    this.fetchMessageService = new FetchMessageServiceImpl();
-    this.decodeMessageService = new DecodeMessageServiceImpl();
-  }
+    public OnboardingServiceImpl() {
+        this.encodeMessageService = new EncodeMessageServiceImpl();
+        this.fetchMessageService = new FetchMessageServiceImpl();
+        this.decodeMessageService = new DecodeMessageServiceImpl();
+    }
 
-  /**
-   * Onboarding a virtual CU for an existing cloud application (incl. several checks).
-   *
-   * @param parameters Parameters for the onboarding.
-   * @return -
-   */
-  @Override
-  public List<OnboardingResponse> onboard(CloudOnboardingParameters parameters) {
-    parameters.validate();
-    EncodeMessageResponse encodedMessageResponse = this.encodeOnboardingMessage(parameters);
-    SendMessageParameters sendMessageParameters =
-        createSendMessageParameters(encodedMessageResponse, parameters.getOnboardingResponse());
-    Optional<List<FetchMessageResponse>> fetchMessageResponses =
-        sendMessageAndFetchResponses(sendMessageParameters, parameters.getOnboardingResponse());
+    /**
+     * Onboarding a virtual CU for an existing cloud application (incl. several checks).
+     *
+     * @param parameters Parameters for the onboarding.
+     * @return -
+     */
+    @Override
+    public List<OnboardingResponse> onboard(CloudOnboardingParameters parameters) {
+        parameters.validate();
+        EncodeMessageResponse encodedMessageResponse = this.encodeOnboardingMessage(parameters);
+        SendMessageParameters sendMessageParameters =
+                createSendMessageParameters(encodedMessageResponse, parameters.getOnboardingResponse());
+        Optional<List<FetchMessageResponse>> fetchMessageResponses =
+                sendMessageAndFetchResponses(sendMessageParameters, parameters.getOnboardingResponse());
 
-    List<OnboardingResponse> responses = new ArrayList<>();
-    if (fetchMessageResponses.isPresent()) {
-      DecodeMessageResponse decodedMessageQueryResponse =
-          this.decodeMessageService.decode(
-              fetchMessageResponses.get().get(0).getCommand().getMessage());
-      if (decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
-          == HttpStatus.SC_BAD_REQUEST) {
-        MessageOuterClass.Message message =
-            this.decodeMessageService.decode(
-                decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
-        throw new CouldNotOnboardVirtualCommunicationUnitException(message.getMessage());
-      } else {
-        if (decodedMessageQueryResponse.getResponseEnvelope().getType()
-                == Response.ResponseEnvelope.ResponseBodyType.CLOUD_REGISTRATIONS
-            && decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
-                == HttpStatus.SC_CREATED) {
-          CloudVirtualizedAppRegistration.OnboardingResponse onboardingResponse =
-              this.decode(
-                  decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
-          onboardingResponse
-              .getOnboardedEndpointsList()
-              .forEach(
-                  endpointRegistrationDetails -> {
-                    OnboardingResponse internalOnboardingResponse = new OnboardingResponse();
-                    internalOnboardingResponse.setSensorAlternateId(
-                        endpointRegistrationDetails.getSensorAlternateId());
-                    internalOnboardingResponse.setCapabilityAlternateId(
-                        endpointRegistrationDetails.getCapabilityAlternateId());
-                    internalOnboardingResponse.setDeviceAlternateId(
-                        endpointRegistrationDetails.getDeviceAlternateId());
-                    internalOnboardingResponse.setAuthentication(
-                        parameters.getOnboardingResponse().getAuthentication());
-                    internalOnboardingResponse.setConnectionCriteria(
-                        parameters.getOnboardingResponse().getConnectionCriteria());
-                    responses.add(internalOnboardingResponse);
-                  });
+        List<OnboardingResponse> responses = new ArrayList<>();
+        if (fetchMessageResponses.isPresent()) {
+            DecodeMessageResponse decodedMessageQueryResponse =
+                    this.decodeMessageService.decode(
+                            fetchMessageResponses.get().get(0).getCommand().getMessage());
+            if (decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
+                    == HttpStatus.SC_BAD_REQUEST) {
+                MessageOuterClass.Message message =
+                        this.decodeMessageService.decode(
+                                decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
+                throw new CouldNotOnboardVirtualCommunicationUnitException(message.getMessage());
+            } else {
+                if (decodedMessageQueryResponse.getResponseEnvelope().getType()
+                        == Response.ResponseEnvelope.ResponseBodyType.CLOUD_REGISTRATIONS
+                        && decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
+                        == HttpStatus.SC_CREATED) {
+                    CloudVirtualizedAppRegistration.OnboardingResponse onboardingResponse =
+                            this.decode(
+                                    decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
+                    onboardingResponse
+                            .getOnboardedEndpointsList()
+                            .forEach(
+                                    endpointRegistrationDetails -> {
+                                        OnboardingResponse internalOnboardingResponse = new OnboardingResponse();
+                                        internalOnboardingResponse.setSensorAlternateId(
+                                                endpointRegistrationDetails.getSensorAlternateId());
+                                        internalOnboardingResponse.setCapabilityAlternateId(
+                                                endpointRegistrationDetails.getCapabilityAlternateId());
+                                        internalOnboardingResponse.setDeviceAlternateId(
+                                                endpointRegistrationDetails.getDeviceAlternateId());
+                                        internalOnboardingResponse.setAuthentication(
+                                                parameters.getOnboardingResponse().getAuthentication());
+                                        internalOnboardingResponse.setConnectionCriteria(
+                                                parameters.getOnboardingResponse().getConnectionCriteria());
+                                        responses.add(internalOnboardingResponse);
+                                    });
+                }
+            }
         }
-      }
+        return responses;
     }
-    return responses;
-  }
 
-  /**
-   * Offboarding a virtual CU. Will deliver no result if the action was successful, if there's any
-   * error an exception will be thrown.
-   *
-   * @param parameters Parameters for offboarding.
-   */
-  @Override
-  public void offboard(CloudOffboardingParameters parameters) {
-    parameters.validate();
-    EncodeMessageResponse encodedMessageResponse = this.encodeOffboardingMessage(parameters);
-    SendMessageParameters sendMessageParameters =
-        createSendMessageParameters(encodedMessageResponse, parameters.getOnboardingResponse());
-    Optional<List<FetchMessageResponse>> fetchMessageResponses =
-        sendMessageAndFetchResponses(sendMessageParameters, parameters.getOnboardingResponse());
-    if (fetchMessageResponses.isPresent()) {
-      DecodeMessageResponse decodedMessageQueryResponse =
-          this.decodeMessageService.decode(
-              fetchMessageResponses.get().get(0).getCommand().getMessage());
-      if (decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
-          == HttpStatus.SC_BAD_REQUEST) {
-        MessageOuterClass.Message message =
-            this.decodeMessageService.decode(
-                decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
-        throw new CouldNotOffboardVirtualCommunicationUnitException(message.getMessage());
-      }
+    /**
+     * Offboarding a virtual CU. Will deliver no result if the action was successful, if there's any
+     * error an exception will be thrown.
+     *
+     * @param parameters Parameters for offboarding.
+     */
+    @Override
+    public void offboard(CloudOffboardingParameters parameters) {
+        parameters.validate();
+        EncodeMessageResponse encodedMessageResponse = this.encodeOffboardingMessage(parameters);
+        SendMessageParameters sendMessageParameters =
+                createSendMessageParameters(encodedMessageResponse, parameters.getOnboardingResponse());
+        Optional<List<FetchMessageResponse>> fetchMessageResponses =
+                sendMessageAndFetchResponses(sendMessageParameters, parameters.getOnboardingResponse());
+        if (fetchMessageResponses.isPresent()) {
+            DecodeMessageResponse decodedMessageQueryResponse =
+                    this.decodeMessageService.decode(
+                            fetchMessageResponses.get().get(0).getCommand().getMessage());
+            if (decodedMessageQueryResponse.getResponseEnvelope().getResponseCode()
+                    == HttpStatus.SC_BAD_REQUEST) {
+                MessageOuterClass.Message message =
+                        this.decodeMessageService.decode(
+                                decodedMessageQueryResponse.getResponsePayloadWrapper().getDetails().getValue());
+                throw new CouldNotOffboardVirtualCommunicationUnitException(message.getMessage());
+            }
+        }
     }
-  }
 
-  private Optional<List<FetchMessageResponse>> sendMessageAndFetchResponses(
-      SendMessageParameters sendMessageParameters, OnboardingResponse onboardingResponse) {
-    MessageSenderResponse response = this.sendMessage(sendMessageParameters);
-    this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK);
-    return this.fetchMessageService.fetch(
-        onboardingResponse, MAX_TRIES_BEFORE_FAILURE, DEFAULT_INTERVAL);
-  }
+    private Optional<List<FetchMessageResponse>> sendMessageAndFetchResponses(
+            SendMessageParameters sendMessageParameters, OnboardingResponse onboardingResponse) {
+        MessageSenderResponse response = this.sendMessage(sendMessageParameters);
+        this.assertResponseStatusIsValid(response.getNativeResponse(), HttpStatus.SC_OK);
+        return this.fetchMessageService.fetch(
+                onboardingResponse, MAX_TRIES_BEFORE_FAILURE, DEFAULT_INTERVAL);
+    }
 
-  private EncodeMessageResponse encodeOnboardingMessage(CloudOnboardingParameters parameters) {
-    final String applicationMessageID = MessageIdService.generateMessageId();
+    private EncodeMessageResponse encodeOnboardingMessage(CloudOnboardingParameters parameters) {
+        final String applicationMessageID = MessageIdService.generateMessageId();
 
-    List<CloudEndpointOnboardingMessageParameters> onboardCloudEndpointMessageParameters =
-        new ArrayList<>();
-    parameters
-        .getEndpointDetails()
-        .forEach(
-            endpointDetailsParameters -> {
-              CloudEndpointOnboardingMessageParameters onboardCloudEndpointMessageParameter =
-                  new CloudEndpointOnboardingMessageParameters();
-              onboardCloudEndpointMessageParameter.setEndpointId(
-                  endpointDetailsParameters.getEndpointId());
-              onboardCloudEndpointMessageParameter.setEndpointName(
-                  endpointDetailsParameters.getEndpointName());
-              onboardCloudEndpointMessageParameters.add(onboardCloudEndpointMessageParameter);
-            });
+        List<CloudEndpointOnboardingMessageParameters> onboardCloudEndpointMessageParameters =
+                new ArrayList<>();
+        parameters
+                .getEndpointDetails()
+                .forEach(
+                        endpointDetailsParameters -> {
+                            CloudEndpointOnboardingMessageParameters onboardCloudEndpointMessageParameter =
+                                    new CloudEndpointOnboardingMessageParameters();
+                            onboardCloudEndpointMessageParameter.setEndpointId(
+                                    endpointDetailsParameters.getEndpointId());
+                            onboardCloudEndpointMessageParameter.setEndpointName(
+                                    endpointDetailsParameters.getEndpointName());
+                            onboardCloudEndpointMessageParameters.add(onboardCloudEndpointMessageParameter);
+                        });
 
-    PayloadParameters payloadParameters = new PayloadParameters();
-    payloadParameters.setTypeUrl(
-        CloudVirtualizedAppRegistration.OnboardingRequest.getDescriptor().getFullName());
-    payloadParameters.setValue(
-        new CloudEndpointOnboardingMessageContentFactory()
-            .message(
-                onboardCloudEndpointMessageParameters.toArray(
-                    new CloudEndpointOnboardingMessageParameters
-                        [onboardCloudEndpointMessageParameters.size()])));
+        PayloadParameters payloadParameters = new PayloadParameters();
+        payloadParameters.setTypeUrl(
+                CloudVirtualizedAppRegistration.OnboardingRequest.getDescriptor().getFullName());
+        payloadParameters.setValue(
+                new CloudEndpointOnboardingMessageContentFactory()
+                        .message(
+                                onboardCloudEndpointMessageParameters.toArray(
+                                        new CloudEndpointOnboardingMessageParameters
+                                                [onboardCloudEndpointMessageParameters.size()])));
 
-    String encodedMessage =
-        this.encodeMessageService.encode(
-            this.createMessageHeaderParameters(applicationMessageID), payloadParameters);
-    return new EncodeMessageResponse(applicationMessageID, encodedMessage);
-  }
+        String encodedMessage =
+                this.encodeMessageService.encode(
+                        this.createMessageHeaderParameters(applicationMessageID), payloadParameters);
+        return new EncodeMessageResponse(applicationMessageID, encodedMessage);
+    }
 
-  private EncodeMessageResponse encodeOffboardingMessage(CloudOffboardingParameters parameters) {
-    final String applicationMessageID = MessageIdService.generateMessageId();
+    private EncodeMessageResponse encodeOffboardingMessage(CloudOffboardingParameters parameters) {
+        final String applicationMessageID = MessageIdService.generateMessageId();
 
-    CloudEndpointOffboardingMessageParameters cloudOffboardingParameters =
-        new CloudEndpointOffboardingMessageParameters();
-    cloudOffboardingParameters.setEndpointIds(new ArrayList<>());
-    parameters
-        .getEndpointIds()
-        .forEach(
-            endpointId -> {
-              cloudOffboardingParameters.getEndpointIds().add(endpointId);
-            });
+        CloudEndpointOffboardingMessageParameters cloudOffboardingParameters =
+                new CloudEndpointOffboardingMessageParameters();
+        cloudOffboardingParameters.setEndpointIds(new ArrayList<>());
+        parameters
+                .getEndpointIds()
+                .forEach(
+                        endpointId -> {
+                            cloudOffboardingParameters.getEndpointIds().add(endpointId);
+                        });
 
-    PayloadParameters payloadParameters = new PayloadParameters();
-    payloadParameters.setTypeUrl(
-        CloudVirtualizedAppRegistration.OffboardingRequest.getDescriptor().getFullName());
+        PayloadParameters payloadParameters = new PayloadParameters();
+        payloadParameters.setTypeUrl(
+                CloudVirtualizedAppRegistration.OffboardingRequest.getDescriptor().getFullName());
 
-    payloadParameters.setValue(
-        new CloudEndpointOffboardingMessageContentFactory().message(cloudOffboardingParameters));
+        payloadParameters.setValue(
+                new CloudEndpointOffboardingMessageContentFactory().message(cloudOffboardingParameters));
 
-    String encodedMessage =
-        this.encodeMessageService.encode(
-            this.createMessageHeaderParameters(applicationMessageID), payloadParameters);
-    return new EncodeMessageResponse(applicationMessageID, encodedMessage);
-  }
+        String encodedMessage =
+                this.encodeMessageService.encode(
+                        this.createMessageHeaderParameters(applicationMessageID), payloadParameters);
+        return new EncodeMessageResponse(applicationMessageID, encodedMessage);
+    }
 
-  private MessageHeaderParameters createMessageHeaderParameters(String applicationMessageID) {
-    MessageHeaderParameters messageHeaderParameters = new MessageHeaderParameters();
-    messageHeaderParameters.setApplicationMessageId(applicationMessageID);
-    messageHeaderParameters.setTechnicalMessageType(
-        TechnicalMessageType.DKE_CLOUD_ONBOARD_ENDPOINTS);
-    messageHeaderParameters.setMode(Request.RequestEnvelope.Mode.DIRECT);
-    return messageHeaderParameters;
-  }
+    private MessageHeaderParameters createMessageHeaderParameters(String applicationMessageID) {
+        MessageHeaderParameters messageHeaderParameters = new MessageHeaderParameters();
+        messageHeaderParameters.setApplicationMessageId(applicationMessageID);
+        messageHeaderParameters.setTechnicalMessageType(
+                TechnicalMessageType.DKE_CLOUD_ONBOARD_ENDPOINTS);
+        messageHeaderParameters.setMode(Request.RequestEnvelope.Mode.DIRECT);
+        return messageHeaderParameters;
+    }
 
-  private SendMessageParameters createSendMessageParameters(
-      EncodeMessageResponse encodedMessageResponse, OnboardingResponse onboardingResponse) {
-    SendMessageParameters sendMessageParameters = new SendMessageParameters();
-    sendMessageParameters.setOnboardingResponse(onboardingResponse);
-    sendMessageParameters.setEncodedMessages(
-        Collections.singletonList(encodedMessageResponse.getEncodedMessage()));
-    return sendMessageParameters;
-  }
+    private SendMessageParameters createSendMessageParameters(
+            EncodeMessageResponse encodedMessageResponse, OnboardingResponse onboardingResponse) {
+        SendMessageParameters sendMessageParameters = new SendMessageParameters();
+        sendMessageParameters.setOnboardingResponse(onboardingResponse);
+        sendMessageParameters.setEncodedMessages(
+                Collections.singletonList(encodedMessageResponse.getEncodedMessage()));
+        return sendMessageParameters;
+    }
 
-  @Override
-  public CloudVirtualizedAppRegistration.OnboardingResponse unsafeDecode(ByteString message)
-      throws InvalidProtocolBufferException {
-    return CloudVirtualizedAppRegistration.OnboardingResponse.parseFrom(message);
-  }
+    @Override
+    public CloudVirtualizedAppRegistration.OnboardingResponse unsafeDecode(ByteString message)
+            throws InvalidProtocolBufferException {
+        return CloudVirtualizedAppRegistration.OnboardingResponse.parseFrom(message);
+    }
 }

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/secured/RegistrationRequestServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/onboard/secured/RegistrationRequestServiceImpl.java
@@ -2,7 +2,6 @@ package com.dke.data.agrirouter.impl.onboard.secured;
 
 import com.dke.data.agrirouter.api.dto.registrationrequest.secured.RegistrationRequestResponse;
 import com.dke.data.agrirouter.api.dto.registrationrequest.secured.RegistrationRequestToken;
-import com.dke.data.agrirouter.api.enums.SecuredOnboardingResponseType;
 import com.dke.data.agrirouter.api.env.Environment;
 import com.dke.data.agrirouter.api.exception.CouldNotGetRegistrationCodeException;
 import com.dke.data.agrirouter.api.service.onboard.OnboardingService;
@@ -63,8 +62,9 @@ public class RegistrationRequestServiceImpl extends EnvironmentalService
         securedRegistrationRequestParameters.getApplicationId());
     authenticationUrlParameters.setRedirectUri(
         securedRegistrationRequestParameters.getRedirectUri());
-    authenticationUrlParameters.setResponseType(SecuredOnboardingResponseType.ONBOARD);
-    if (securedRegistrationRequestParameters.getState().equals("")) {
+    authenticationUrlParameters.setResponseType(
+        securedRegistrationRequestParameters.getResponseType());
+    if (securedRegistrationRequestParameters.getState() == null) {
       securedRegistrationRequestParameters.setState(StateIdService.generateState());
     }
     authenticationUrlParameters.setState(securedRegistrationRequestParameters.getState());


### PR DESCRIPTION
The RegistrationRequestService currently only supports generating Registration Codes with UserName and password and without UserInteraction. This is good for automated tested (and should therefore persist), it is however not usefull for implementations using the process as designed.

+ADD: State can be set by Implementor
=CHG: Made some functions public to extract the AuthenticationURL and analyse the Result
-FIX: The function name decode is not clear, therefor renamed to "decodeToken";