### PR TITLE
send chunk info as necessary

### DIFF
--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/encoding/EncodeMessageServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/encoding/EncodeMessageServiceImpl.java
@@ -61,6 +61,9 @@ public class EncodeMessageServiceImpl extends NonEnvironmentalService
     if (!parameters.getRecipients().isEmpty()) {
       messageHeader.addAllRecipients(parameters.getRecipients());
     }
+    if (parameters.getChunkInfo() != null) {
+      messageHeader.setChunkInfo(parameters.getChunkInfo());
+    }
     messageHeader.setTimestamp(new TimestampUtil().current());
 
     this.getNativeLogger().trace("Build message envelope.");


### PR DESCRIPTION
Currently the chunk info is ignored and not sent to the agrirouter.
That way every chunk is handled as a separate message.

This pull request sets the chunk info in the message header as it was obviously intended.