### PR TITLE
Renamed the Helper class MessageQueryService to MessageQueryHelperService

### DIFF
--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/helper/MessageQueryHelperService.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/helper/MessageQueryHelperService.java
@@ -11,13 +11,13 @@ import com.dke.data.agrirouter.impl.messaging.rest.MessageSender;
 import com.dke.data.agrirouter.impl.validation.ResponseValidator;
 import java.util.Collections;
 
-public class MessageQueryService extends NonEnvironmentalService
+public class MessageQueryHelperService extends NonEnvironmentalService
     implements MessageSender, MessageEncoder, ResponseValidator {
 
   private final EncodeMessageService encodeMessageService;
   private final TechnicalMessageType technicalMessageType;
 
-  public MessageQueryService(
+  public MessageQueryHelperService(
       EncodeMessageService encodeMessageService, TechnicalMessageType technicalMessageType) {
     this.logMethodBegin();
     this.encodeMessageService = encodeMessageService;

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/helper/mqtt/MessageQueryHelperService.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/helper/mqtt/MessageQueryHelperService.java
@@ -14,12 +14,13 @@ import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 
-public class MessageQueryService extends MqttService implements MessageSender, MessageEncoder {
+public class MessageQueryHelperService extends MqttService
+    implements MessageSender, MessageEncoder {
 
   private final EncodeMessageService encodeMessageService;
   private final TechnicalMessageType technicalMessageType;
 
-  public MessageQueryService(
+  public MessageQueryHelperService(
       MqttClient mqttClient,
       EncodeMessageService encodeMessageService,
       TechnicalMessageType technicalMessageType) {

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/mqtt/MessageHeaderQueryServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/mqtt/MessageHeaderQueryServiceImpl.java
@@ -6,7 +6,7 @@ import com.dke.data.agrirouter.api.service.messaging.MessageHeaderQueryService;
 import com.dke.data.agrirouter.api.service.parameters.MessageQueryParameters;
 import com.dke.data.agrirouter.impl.messaging.MqttService;
 import com.dke.data.agrirouter.impl.messaging.encoding.EncodeMessageServiceImpl;
-import com.dke.data.agrirouter.impl.messaging.helper.mqtt.MessageQueryService;
+import com.dke.data.agrirouter.impl.messaging.helper.mqtt.MessageQueryHelperService;
 import com.dke.data.agrirouter.impl.messaging.rest.MessageSender;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -15,18 +15,18 @@ import org.eclipse.paho.client.mqttv3.MqttClient;
 public class MessageHeaderQueryServiceImpl extends MqttService
     implements MessageHeaderQueryService, MessageSender {
 
-  private final MessageQueryService messageQueryService;
+  private final MessageQueryHelperService messageQueryHelperService;
 
   public MessageHeaderQueryServiceImpl(MqttClient mqttClient) {
     super(mqttClient);
-    messageQueryService =
-        new MessageQueryService(
+    messageQueryHelperService =
+        new MessageQueryHelperService(
             mqttClient, new EncodeMessageServiceImpl(), TechnicalMessageType.DKE_FEED_HEADER_QUERY);
   }
 
   @Override
   public String send(MessageQueryParameters parameters) {
-    return this.messageQueryService.send(parameters);
+    return this.messageQueryHelperService.send(parameters);
   }
 
   @Override

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/mqtt/MessageQueryServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/mqtt/MessageQueryServiceImpl.java
@@ -6,7 +6,7 @@ import com.dke.data.agrirouter.api.service.messaging.encoding.MessageDecoder;
 import com.dke.data.agrirouter.api.service.parameters.MessageQueryParameters;
 import com.dke.data.agrirouter.impl.messaging.MqttService;
 import com.dke.data.agrirouter.impl.messaging.encoding.EncodeMessageServiceImpl;
-import com.dke.data.agrirouter.impl.messaging.helper.mqtt.MessageQueryService;
+import com.dke.data.agrirouter.impl.messaging.helper.mqtt.MessageQueryHelperService;
 import com.dke.data.agrirouter.impl.messaging.rest.MessageSender;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -17,12 +17,12 @@ public class MessageQueryServiceImpl extends MqttService
         MessageSender,
         MessageDecoder<FeedResponse.MessageQueryResponse> {
 
-  private final MessageQueryService messageQueryService;
+  private final MessageQueryHelperService messageQueryHelperService;
 
   public MessageQueryServiceImpl(MqttClient mqttClient) {
     super(mqttClient);
-    this.messageQueryService =
-        new MessageQueryService(
+    this.messageQueryHelperService =
+        new MessageQueryHelperService(
             mqttClient,
             new EncodeMessageServiceImpl(),
             TechnicalMessageType.DKE_FEED_MESSAGE_QUERY);
@@ -30,7 +30,7 @@ public class MessageQueryServiceImpl extends MqttService
 
   @Override
   public String send(MessageQueryParameters parameters) {
-    return this.messageQueryService.send(parameters);
+    return this.messageQueryHelperService.send(parameters);
   }
 
   @Override

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageHeaderQueryServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageHeaderQueryServiceImpl.java
@@ -7,25 +7,25 @@ import com.dke.data.agrirouter.api.service.messaging.MessageHeaderQueryService;
 import com.dke.data.agrirouter.api.service.parameters.MessageQueryParameters;
 import com.dke.data.agrirouter.impl.EnvironmentalService;
 import com.dke.data.agrirouter.impl.messaging.encoding.EncodeMessageServiceImpl;
-import com.dke.data.agrirouter.impl.messaging.helper.MessageQueryService;
+import com.dke.data.agrirouter.impl.messaging.helper.MessageQueryHelperService;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 public class MessageHeaderQueryServiceImpl extends EnvironmentalService
     implements MessageHeaderQueryService, MessageSender {
 
-  private final MessageQueryService messageQueryService;
+  private final MessageQueryHelperService messageQueryHelperService;
 
   public MessageHeaderQueryServiceImpl(Environment environment) {
     super(environment);
-    messageQueryService =
-        new MessageQueryService(
+    messageQueryHelperService =
+        new MessageQueryHelperService(
             new EncodeMessageServiceImpl(), TechnicalMessageType.DKE_FEED_HEADER_QUERY);
   }
 
   @Override
   public String send(MessageQueryParameters parameters) {
-    String applicationMessageID = this.messageQueryService.send(parameters);
+    String applicationMessageID = this.messageQueryHelperService.send(parameters);
     return applicationMessageID;
   }
 

--- a/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageQueryServiceImpl.java
+++ b/agrirouter-api-java-impl/src/main/java/com/dke/data/agrirouter/impl/messaging/rest/MessageQueryServiceImpl.java
@@ -7,7 +7,7 @@ import com.dke.data.agrirouter.api.service.messaging.encoding.MessageDecoder;
 import com.dke.data.agrirouter.api.service.parameters.MessageQueryParameters;
 import com.dke.data.agrirouter.impl.EnvironmentalService;
 import com.dke.data.agrirouter.impl.messaging.encoding.EncodeMessageServiceImpl;
-import com.dke.data.agrirouter.impl.messaging.helper.MessageQueryService;
+import com.dke.data.agrirouter.impl.messaging.helper.MessageQueryHelperService;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
@@ -16,18 +16,18 @@ public class MessageQueryServiceImpl extends EnvironmentalService
         MessageSender,
         MessageDecoder<FeedResponse.MessageQueryResponse> {
 
-  private final MessageQueryService messageQueryService;
+  private final MessageQueryHelperService messageQueryHelperService;
 
   public MessageQueryServiceImpl(Environment environment) {
     super(environment);
-    this.messageQueryService =
-        new MessageQueryService(
+    this.messageQueryHelperService =
+        new MessageQueryHelperService(
             new EncodeMessageServiceImpl(), TechnicalMessageType.DKE_FEED_MESSAGE_QUERY);
   }
 
   @Override
   public String send(MessageQueryParameters parameters) {
-    String applicationMessageID = this.messageQueryService.send(parameters);
+    String applicationMessageID = this.messageQueryHelperService.send(parameters);
     return applicationMessageID;
   }
 


### PR DESCRIPTION
There is already an Interface in the API called MessageQueryService, which lead to confusion every now and than